### PR TITLE
Look for the requested room.

### DIFF
--- a/hiplogging/__init__.py
+++ b/hiplogging/__init__.py
@@ -12,7 +12,7 @@ class HipChat(object):
     def find_room_id(self, name):
         room_id = self.room_ids_cache.get(name)
         if not room_id:
-            room_id = self.api.find_room('Pastebin')['room_id']
+            room_id = self.api.find_room(name)['room_id']
             self.room_ids_cache[name] = room_id
         return room_id
 


### PR DESCRIPTION
Previously looking for a room with hardcoded name "Pastebin".

This will still fail poorly if at HipChat object instantiation a
non-existent room name is given though.
