### PR TITLE
Make API v2 compliant

### DIFF
--- a/example.py
+++ b/example.py
@@ -3,15 +3,18 @@ import logging
 import hiplogging
 
 # Set up a standard logger
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
+logger = logging.getLogger('hipchat')
+logger.setLevel(logging.DEBUG)
+
 
 # Add the hipchat handler
 # Get an admin token from: https://<YOUR_HIPCHAT_NAME>.hipchat.com/admin/api
-handler = hiplogging.HipChatHandler(os.environ['HIPCHAT_ADMIN_TOKEN'],
-                                   os.environ['HIPCHAT_ROOM'])
+handler = hiplogging.HipChatHandler(os.environ['HIPCHAT_ACCESS_TOKEN'], os.environ['HIPCHAT_ROOM'])
+# An optional after the HipChat Room is 'environment' for the case of your own HipChat server
+# i.e.: https//hipchat.yourdomain.com
 handler.setLevel(logging.DEBUG)
 logger.addHandler(handler)
+
 
 # Try it out: messages will be visible both in the console and on hipchat.
 logger.debug('debug - we are approaching the anomaly')

--- a/hiplogging/__init__.py
+++ b/hiplogging/__init__.py
@@ -1,67 +1,31 @@
 # -*- coding: utf-8 -*-
-
+""" Refactors hiplogging (https://github.com/invernizzi/hiplogging) to use
+HipChat's API v2 via HypChat (https://github.com/RidersDiscountCom/HypChat)
+"""
 import logging
-import hipchat
-
-
-class HipChat(object):
-
-    def __init__(self, admin_token, default_room):
-        self.api = hipchat.HipChat(token=admin_token)
-        self.default_room = default_room
-        self.room_ids_cache = {}
-
-    def find_room_id(self, name):
-        room_id = self.room_ids_cache.get(name)
-        if not room_id:
-            try:
-                room_id = self.api.find_room(name)['room_id']
-            except TypeError:
-                print('WARNING: hipchat room "{0}" not found!'.format(name))
-                return None
-            self.room_ids_cache[name] = room_id
-        return room_id
-
-    def send_message(self, message, sender='log', color='yellow', room=None, notify=0):
-        if not room:
-            room = self.default_room
-        room_id = self.find_room_id(room)
-        if room_id is None:
-            return
-        self.api.message_room(
-            room_id=room_id,
-            message_from=sender,
-            color=color,
-            message=message,
-            notify=notify,
-        )
+from hypchat import HypChat
 
 
 class HipChatHandler(logging.Handler):
 
-    def __init__(self, admin_token, room, sender=''):
+    def __init__(self, access_token, room_name, endpoint='https://api.hipchat.com'):
         logging.Handler.__init__(self)
-        self.sender = sender
-        self.api = HipChat(admin_token, room)
+        self.room = HypChat(access_token, endpoint).get_room(room_name)
 
     def emit(self, record):
         if hasattr(record, "color"):
             color = record.color
         else:
             color = self.__color_for_level(record.levelno)
-        if hasattr(record, "sender"):
-            sender = record.sender
-        else:
-            sender = '-'.join([n for n in [self.sender, record.levelname] if n])
         if hasattr(record, "notify"):
-            notify = record.notify
+            notify = bool(record.notify)
         else:
             notify = self.__notify_for_level(record.levelno)
-        self.api.send_message(
-            self.format(record),
-            sender=sender,
+        print 'calling emit'
+        self.room.notification(
+            message=self.format(record),
             color=color,
-            notify=notify,
+            notify=notify
         )
 
     def __color_for_level(self, levelno):
@@ -77,11 +41,13 @@ class HipChatHandler(logging.Handler):
 
     def __notify_for_level(self, levelno):
         if levelno > logging.WARNING:
-            return 1
+            return True
         if levelno == logging.WARNING:
-            return 0
+            return False
         if levelno == logging.INFO:
-            return 0
+            return False
         if levelno == logging.DEBUG:
-            return 0
-        return 0
+            return False
+        return False
+
+

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='MIT',
     keywords=['hipchat', 'log', 'logging'],
     download_url = 'https://github.com/invernizzi/hiplogging/tarball/%s' % VERSION,
-    install_requires=['python-simple-hipchat'],
+    install_requires=['hypchat'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
These changes move the reliance on python-simple-hipchat over to hypchat, which makes things API v2 compliant.  This allows users to use their own Access Key instead of needing an Admin Key.