### PR TITLE
Remove hypchat dependency and bring back sender option.

### DIFF
--- a/hiplogging/HipChat.py
+++ b/hiplogging/HipChat.py
@@ -1,0 +1,51 @@
+import requests
+import json
+import six
+
+def jsonify(obj):
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    elif isinstance(obj, set):
+        return list(obj)
+    else:
+        raise TypeError("Can't JSONify objects of type %s" % type(obj).__name__)
+
+class HipChatRoom(object):
+    def __init__(self, token, endpoint='https://api.hipchat.com', room=None):
+        self.token = token
+        self.endpoint = endpoint
+        self.room = room
+        self.url = self.endpoint + '/v2/room/' + room
+
+    def notification(self, message, color=None, notify=False, format=None, sender=None):
+        """
+        Send a message to a room.
+        """
+        if not format:
+            format = 'html'
+        from_label = ""
+
+        message_length = len(message)
+        part_number = 0
+        message_part = message[10000 * part_number :10000 * (part_number + 1)]
+        while message_length > 0:
+            data = {'message': message_part, 'notify': notify, 'message_format': format}
+            if color:
+                data['color'] = color
+            if sender:
+                data['from'] = sender[:64]
+            self.__make_request(url=self.url + '/notification', data=data)
+            part_number += 1
+            message_length -= 10000
+
+
+
+
+    def __make_request(self, url, data):
+        headers = {'Authorization':'Bearer %s' % self.token,
+                   'Content-Type':'application/json'}
+        if not isinstance(data, six.string_types):
+            data = json.dumps(data, default=jsonify)
+
+        r = requests.post(url=url, data=data, headers=headers)
+        print(r.text)

--- a/hiplogging/__init__.py
+++ b/hiplogging/__init__.py
@@ -3,14 +3,13 @@
 HipChat's API v2 via HypChat (https://github.com/RidersDiscountCom/HypChat)
 """
 import logging
-from hypchat import HypChat
-
+from HipChat import HipChatRoom
 
 class HipChatHandler(logging.Handler):
 
     def __init__(self, access_token, room_name, endpoint='https://api.hipchat.com'):
         logging.Handler.__init__(self)
-        self.room = HypChat(access_token, endpoint).get_room(room_name)
+        self.room = HipChatRoom(access_token, endpoint, room_name)
 
     def emit(self, record):
         if hasattr(record, "color"):
@@ -21,10 +20,14 @@ class HipChatHandler(logging.Handler):
             notify = bool(record.notify)
         else:
             notify = self.__notify_for_level(record.levelno)
+        sender = None
+        if hasattr(record,"sender"):
+            sender = record.sender
         self.room.notification(
             message=self.format(record),
             color=color,
-            notify=notify
+            notify=notify,
+            sender=sender
         )
 
     def __color_for_level(self, levelno):
@@ -48,5 +51,3 @@ class HipChatHandler(logging.Handler):
         if levelno == logging.DEBUG:
             return False
         return False
-
-

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION='1.2.1'
+VERSION='1.2.2'
 
 setup(
     description='HipChat support for the Python logging module',
@@ -13,7 +13,6 @@ setup(
     license='MIT',
     keywords=['hipchat', 'log', 'logging'],
     download_url = 'https://github.com/invernizzi/hiplogging/tarball/%s' % VERSION,
-    install_requires=['hypchat'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Removed dependency for hypchat. This library is not actively developed and had limited features. Since we only use room notifications a new class was created that will check the length of the message being sent and will not fail if it is greater than 10000 now. It also allows the from property to be set which was present in the README but this feature was taken away after using hypchat. 
This should fix #11 and #15.